### PR TITLE
Show ad overlay on hover

### DIFF
--- a/_css/style.css
+++ b/_css/style.css
@@ -4474,3 +4474,19 @@ img.mfp-img {
     opacity: 0.5;
     z-index:2;
   }
+
+/* Custom ad-box mouseovers */
+.newsbox.section-ad .info_block {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+  -moz-transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+  -webkit-transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+}
+.newsbox.section-ad:hover .info_block {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 2s linear;
+  -moz-transition: opacity 2s linear;
+  -webkit-transition: opacity 2s linear;
+}

--- a/_css/style.less
+++ b/_css/style.less
@@ -276,7 +276,21 @@ p a[href^='http://www.journal-b.ch'], p a[href^='http://dev.journal-b.ch'], p a[
     white-space:normal;
 }
 
-
+/* Custom ad-box mouseovers */
+.newsbox.section-ad .info_block {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+  -moz-transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+  -webkit-transition: visibility 0s linear 0.3s,opacity 0.4s linear;
+}
+.newsbox.section-ad:hover .info_block {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 2s linear;
+  -moz-transition: opacity 2s linear;
+  -webkit-transition: opacity 2s linear;
+}
 
 img.responsive{
   max-width:100%;


### PR DESCRIPTION
Removes the overlay on advertisement newsboxes, making it reappear with a fade-in on mouse hover.

Due to the issue I raised in #42 I have appended the style changes requested to both the LESS and current CSS files.