### PR TITLE
IM-3151 - Bug: Author image from author profile disappears when site …

### DIFF
--- a/_tpl/community-authors.tpl
+++ b/_tpl/community-authors.tpl
@@ -4,7 +4,7 @@
 		{{ if $gimme->current_list->at_beginning }}
 		<div class="row adbox authorbox">
 			<div class="community-title grey">Autor/Autorin</div>
-			<div class="description">
+			<div class="description1">
 		{{ /if }}
 			{{ $ren = false }}
 			{{ foreach from=$rendered_authors item=author }} {{ if $author == $gimme->author->name }} {{ $ren = true }} {{ break }} {{ /if }} {{ /foreach }}


### PR DESCRIPTION
…is fully loaded Image gets lost and author name loses css styling (is not shown in bold)

fixed